### PR TITLE
Fix InfiniteScrollAsync bug when load more fails

### DIFF
--- a/src/createInfiniteScrollAsyncCollectionBundle.js
+++ b/src/createInfiniteScrollAsyncCollectionBundle.js
@@ -139,6 +139,8 @@ export default function createInfiniteScrollAsyncCollectionBundle(inputOptions) 
       }
 
       return {
+        ...state,
+        
         loadMoreRequestId: null,
         loadMoreError: error,
         loadMoreErrorAt: appTime,


### PR DESCRIPTION
Currently dependency tracking is failing when LOAD_MORE_FAILED is triggered because the dependency value (which is not explicitly defined in the bundle) is not referenced when returning state.